### PR TITLE
docs: fix simple typo, witout -> without

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -484,7 +484,7 @@ class Foursquare:
                 token=token)
 
         # If the return type is the request_url, simply build the URL and
-        # return it witout executing anything
+        # return it without executing anything
         if 'returns' in meta and meta['returns'] == 'request_url':
             return cred_url
 


### PR DESCRIPTION
There is a small typo in foursquare/__init__.py.

Should read `without` rather than `witout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md